### PR TITLE
Add upcoming events list from meetup.com's API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 * **Grunt Plugins** – Run `npm install`
 
-* **Bower Dependencies** - Run `bower install classie snap.svg`
+* **Bower Dependencies** - Run `bower install`
 
 * **Livereload Browser Extension** – [http://livereload.com/extensions/](http://livereload.com/extensions/)
 

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -1,0 +1,11 @@
+<script src="/bower_components/reqwest/reqwest.min.js"></script>
+<script src="/bower_components/strftime/strftime-min.js"></script>
+<script src="/assets/js/upcoming-events.js"></script>
+
+<section id="upcoming-events" class="is-hidden">
+  <h1>Join our next events!</h1>
+  <ul id="upcoming-events-list">
+  </ul>
+  <p>For updates when to register: <a href="https://twitter.com/{{ site.twitter_username }}" class="btn" target="_blank">Follow @{{ site.twitter_username }}</a></p>
+  <hr>
+</section>

--- a/_scss/_visuals.scss
+++ b/_scss/_visuals.scss
@@ -32,3 +32,7 @@ $icons:(twitter, github, website);
   margin-right: $base-unit;
   margin-left: $base-unit;
 }
+
+.is-hidden {
+  display: none;
+}

--- a/assets/js/upcoming-events.js
+++ b/assets/js/upcoming-events.js
@@ -1,0 +1,88 @@
+(function () {
+  var upcomingEvents = function () {
+    var reqwestOptions = {
+      url: 'https://api.meetup.com/2/open_events',
+      method: 'get',
+      type: 'jsonp',
+      data: {
+        and_text: 'False',
+        desc: 'False',
+        format: 'json',
+        limited_events: 'False',
+        offset: 0,
+        only: 'time,venue,event_url',
+        'photo-host': 'public',
+        page: 20,
+        radius: 25.0,
+        status: 'upcoming',
+        sig_id: '111973952',
+        sig: '5992951a7b154c83b404c2ae95bf932738813c03',
+        text: 'CSSclasses'
+      }
+    };
+
+    var renderUpcomingEventDate = function (upcomingEvent) {
+      var template = [
+        '<strong>When:</strong>',
+        strftime('%A, %B %o, %I:%M%P-ca. 6:00pm', new Date(upcomingEvent.time))
+      ];
+
+      return template.join(' ');
+    };
+
+    var renderUpcomingEventLocation = function (upcomingEvent) {
+      var eventVenue = upcomingEvent.venue;
+      var linkLabel = eventVenue.name + ', ' + eventVenue.address_1 + ', ' + eventVenue.city;
+      var template = [
+        '<strong>Where:</strong>',
+        '<a href="' + upcomingEvent.event_url + '" target="_blank">' + linkLabel + '</a>'
+      ];
+
+      return template.join(' ');
+    };
+
+    var renderUpcomingEvent = function (upcomingEvent) {
+      var template = [
+        '<li>',
+          '<ul class="list-simple">',
+            '<li class="list-simple__el">',
+              renderUpcomingEventDate(upcomingEvent),
+            '</li>',
+            '<li class="list-simple__el">',
+              renderUpcomingEventLocation(upcomingEvent),
+            '</li>',
+          '</ul>',
+        '</li>'
+      ];
+
+      return template.join(' ');
+    };
+
+    var renderUpcomingEvents = function (upcomingEvents) {
+      if (!upcomingEvents.length) {
+        return;
+      }
+
+      var upcomingEventsEl = document.getElementById('upcoming-events');
+      var upcomingEventsListEl = document.getElementById('upcoming-events-list');
+      var eventsListHtml = upcomingEvents.map(renderUpcomingEvent);
+
+      upcomingEventsListEl.innerHTML = eventsListHtml;
+      upcomingEventsEl.classList.remove('is-hidden');
+    };
+
+    var getEvents = function (callback) {
+      reqwest(reqwestOptions).then(callback);
+    };
+
+    var render = function () {
+      getEvents(function (res) {
+        renderUpcomingEvents(res.results);
+      });
+    };
+
+    return Object.freeze({ render: render });
+  };
+
+  upcomingEvents().render();
+}(reqwest, strftime));

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "moby",
+  "version": "0.1.0",
+  "homepage": "https://github.com/verpixelt/moby",
+  "description": "Codename: moby",
+  "authors": [
+    "Kevin Lorenz",
+    "Łukasz Kliś"
+  ],
+  "license": "CC BY-SA 3.0",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "devDependencies": {
+    "classie": "~1.0.1",
+    "reqwest": "~2.0.3",
+    "snap.svg": "~0.4.1",
+    "strftime": "~0.9.2"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,26 +1,8 @@
 ---
 layout: default
 ---
+{% include upcoming-events.html %}
 <section>
-  <h1>Join our next events!</h1>
-  <ul>
-    <li>
-      <ul class="list-simple">
-        <li class="list-simple__el"><strong>When:</strong> Sunday, August 16th, 10:00am - ca. 6pm</li>
-        <li class="list-simple__el"><strong>Where:</strong> In Dortmund, somewhere around the <a href="/">OpenTechSchool Conference</a>.</li>
-      </ul>
-    </li>
-    <li>
-      <ul class="list-simple">
-        <li class="list-simple__el"><strong>When:</strong> Sunday, September 20th, 10:30am - ca. 6pm </li>
-        <li class="list-simple__el"><strong>Where:</strong> <a href="http://co-up.de/" target="_blank">co.up</a>, Adalbertstraße 7, 10999 Berlin.</li>
-      </ul>
-    </li>
-  </ul>
-  <p>For updates when to register: <a href="/" class="btn">Follow @cssclasses</a></p>
-</section>
-<section>
-  <hr>
   <p>
     The day will include an optional workshop for beginners (and anyone who feels like refreshing their basics), as well as free hacking and collaborating for experts and newbies alike. Around 6pm, we’ll wrap up and everyone is invited to demo their achievements. Afterwards, we’ll end the day with celebratory drinks and socializing at co.up!
   </p>
@@ -42,3 +24,4 @@ layout: default
   <h2>Who is organizing this?</h2>
   <p>The volunteer teams behind CSSconf EU and Open Tech School. We have experience in teaching workshops and organzing events, and our motivation is to share knowledge and passion for building fun and beautiful things for the web. We subscribe to the core values of Open Tech School and are committed to create a safe and encouraging space for learners and coaches.</p>
 </section>
+


### PR DESCRIPTION
Fixes #18. API fetches only the upcoming events with "CSSclasses" phrase in the name.