### PR TITLE
add is-scrolled class to menu button once the header is scrolled

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -38,6 +38,7 @@
   </script>
   <script src="/assets/js/highlight.pack.js"></script>
   <script src="/assets/js/switch.js"></script>
+  <script src="/assets/js/scrollMenu.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>
   <script src="bower_components/snap.svg/dist/snap.svg-min.js"></script>
 </head>

--- a/assets/js/scrollMenu.js
+++ b/assets/js/scrollMenu.js
@@ -1,0 +1,19 @@
+document.addEventListener("DOMContentLoaded", function(event) {
+  var container = document.body.children[0];
+  
+  var checkScroll = function () {
+    var scrollPosition = container.scrollTop;
+    var headerHeight = document.getElementsByTagName('header')[0].clientHeight;
+    var menuButton = document.getElementById('open-button');
+
+    if (scrollPosition > headerHeight) {
+      menuButton.classList.add('is-scrolled');
+    } else {
+      menuButton.classList.remove('is-scrolled');
+    }
+  }
+
+  container.addEventListener('scroll', function () {
+    checkScroll()
+  });
+});


### PR DESCRIPTION
Once the header gets scrolled past, the 'open-button' element gets the class 'is-scrolled'.

(Sorry for the super speed/weird layout gif. Something borked in the export)

![out](https://cloud.githubusercontent.com/assets/593574/9881251/63f7ca18-5bcf-11e5-8fab-0ed21986e8af.gif)
